### PR TITLE
fix:added File interface for functions' return value

### DIFF
--- a/src/fileListFromPath.ts
+++ b/src/fileListFromPath.ts
@@ -2,12 +2,13 @@ import { readdirSync, statSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 
+import { File } from './fileListFromZip';
 /**
  * Generate a FileList from a directory path
  * @param path
- * @returns
+ * @returns FileList
  */
-export function fileListFromPath(path: string) {
+export function fileListFromPath(path: string): File[] {
   const fileList: File[] = [];
   appendFiles(fileList, path);
   return fileList;
@@ -21,7 +22,6 @@ function appendFiles(fileList: File[], currentDir: string) {
     if (stat.isDirectory()) {
       appendFiles(fileList, current);
     } else {
-      // @ts-expect-error We didn't implement all the requires properties
       fileList.push({
         name: entry,
         size: stat.size,

--- a/src/fileListFromZip.ts
+++ b/src/fileListFromZip.ts
@@ -5,9 +5,19 @@ type ZipFile = Parameters<typeof JSZip.loadAsync>[0];
 /**
  * Create a FileList from a zip
  * @param zipContent
- * @returns
+ * @returns File - Array storing the files retrieved
  */
-export async function fileListFromZip(zipContent: ZipFile) {
+export type MTimeMS = number;
+export interface File {
+  name: string;
+  webkitRelativePath: string;
+  lastModified: Date | MTimeMS;
+  size: number;
+  text: () => Promise<string>;
+  arrayBuffer: () => Promise<ArrayBuffer>;
+}
+
+export async function fileListFromZip(zipContent: ZipFile): Promise<File[]> {
   const jsZip = new JSZip();
 
   const zip = await jsZip.loadAsync(zipContent);


### PR DESCRIPTION
Just added the interface 
```
export interface File {
  name: string;
  webkitRelativePath: string;
  lastModified: Date | MTimeMS;
  size: number;
  text: () => Promise<string>;
  arrayBuffer: () => Promise<ArrayBuffer>;
}
```
To be able to better track the return value when using in other modules.