### PR TITLE
fix: lastModified set to milliseconds since unix epoch

### DIFF
--- a/src/fileListFromZip.ts
+++ b/src/fileListFromZip.ts
@@ -18,7 +18,7 @@ export async function fileListFromZip(zipContent: ZipFile) {
     fileList.push({
       name: entry.name.replace(/^.*\//, ''),
       webkitRelativePath: entry.name.replace(/\/.*?$/, ''),
-      lastModified: new Date(entry.date),
+      lastModified: entry.date.getTime(),
       // @ts-expect-error _data is not exposed because missing for folder but it is really there
       size: entry._data.uncompressedSize,
       text: () => {


### PR DESCRIPTION
* The[ interface for File](https://github.com/cheminfo/filelist-from/pull/2#issuecomment-1054457070)
* [jsZip entry.date](https://stuk.github.io/jszip/documentation/api_zipobject.html)
* output of [getTime()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime)

Example/Option for defining the subset of File:
```
type FileList = Omit<File, "stream"|"slice"|"type">[]
```