### PR TITLE
fix: export PartialFile and PartialFileList

### DIFF
--- a/src/PartialFile.ts
+++ b/src/PartialFile.ts
@@ -1,4 +1,0 @@
-/** subset for File */
-
-export type PartialFile = Omit<File, 'stream' | 'slice' | 'type'>;
-export type PartialFileList = PartialFile[];

--- a/src/fileListFromPath.ts
+++ b/src/fileListFromPath.ts
@@ -2,7 +2,7 @@ import { readdirSync, statSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 
-import { PartialFileList } from './PartialFile';
+import { PartialFileList } from './index';
 
 /**
  * Generate a FileList from a directory path

--- a/src/fileListUnzip.ts
+++ b/src/fileListUnzip.ts
@@ -1,5 +1,6 @@
-import { PartialFileList, PartialFile } from './PartialFile';
 import { fileListFromZip } from './fileListFromZip';
+
+import { PartialFileList, PartialFile } from './index';
 
 export async function fileListUnzip(
   fileList: PartialFileList,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
 export * from './fileListFromPath';
 export * from './fileListFromZip';
 export * from './fileListUnzip';
+
+/** subset for File */
+export type PartialFile = Omit<File, 'stream' | 'slice' | 'type'>;
+export type PartialFileList = PartialFile[];


### PR DESCRIPTION
 **PartialFile** and **PartialFileList** are exported from [PartialFile.ts](https://github.com/cheminfo/filelist-from/blob/main/src/PartialFile.ts). This is not exported in the `index.ts`, so those aren't available to load as type definitions for package users.
```
error TS2305: Module '"filelist-from"' has no exported member 'PartialFile'.
```
I pondered these 3 options:

1. Adding `export * from "./PartialFile";` to **index.ts**
2. Add them to `fileListFromZip` or alike
3. Export types from the index.

Option 1 doesn't seem good because [`.ts` output an extra js file.](https://www.typescriptlang.org/docs/handbook/2/type-declarations.html#dts-files)

I did option 3.

There may be better options.

--------------------------

*Sidenote:* webkitRelativePath is defined as readonly in the standards. [This line](https://github.com/cheminfo/filelist-from/blob/1ea4d47786469cc3f4e81c65ef7674be458a3580/src/fileListUnzip.ts#L30) does not error only because [fileListFromZip](https://github.com/cheminfo/filelist-from/blob/1ea4d47786469cc3f4e81c65ef7674be458a3580/src/fileListFromZip.ts#L10) lacks the return type PartialFileList. It may or not be relevant.